### PR TITLE
[FEATURE] Expose package name in ``sha_compare()``

### DIFF
--- a/R/sha_compare.R
+++ b/R/sha_compare.R
@@ -3,6 +3,7 @@
 #' @param repo GitHub repo specification ("owner/pkg").
 #' @param sha_old Character string; base commit SHA/branch/tag.
 #' @param sha_new Character string; commit SHA/branch/tag to test.
+#' @param pkg Name of the package (defaults to `basename(repo)`).
 #' @param entry_fun Name of exported function to invoke (default "main").
 #' @param data Data frame passed as the first argument to `entry_fun`.
 #' @param ... Additional arguments passed on to `entry_fun`.
@@ -10,6 +11,7 @@
 #' @return A list with elements `passed`, `diff`, `old`, `new`.
 #' @export
 sha_compare <- function(repo, sha_old, sha_new,
+                        pkg = basename(repo),
                         entry_fun = "main",
                         data = NULL, ...,
                         diff_fun = waldo::compare) {
@@ -29,7 +31,6 @@ sha_compare <- function(repo, sha_old, sha_new,
 
   run_entry <- function(lib) {
     withr::with_libpaths(lib, action = "prefix", {
-      pkg <- basename(repo)
       fun <- get(entry_fun, envir = asNamespace(pkg))
       args <- if (is.null(data)) {
         extra_args

--- a/tests/testthat/test-sha.R
+++ b/tests/testthat/test-sha.R
@@ -10,6 +10,7 @@ test_that("Outputs are identical across SHAs", {
     repo = "org/pkg",
     sha_old = Sys.getenv("SHA_BASE", "main"),
     sha_new = Sys.getenv("SHA_NEW", "HEAD"),
+    pkg = "pkg",
     entry_fun = "main",
     data = input
   )


### PR DESCRIPTION
## Summary
- add `pkg` argument to `sha_compare()`
- update tests to specify package name