### PR TITLE
[CHORE] Rename package to regressr

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,4 +1,4 @@
-Package: unitr
+Package: regressr
 Title: Minimal SHA Regression Testing Helpers
 Version: 0.0.0.9000
 Authors@R: c(person("Your", "Name", email = "you@example.com", role = c("aut", "cre")))

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,2 +1,2 @@
 export(sha_compare)
-export(print.unitr_result)
+export(print.regressr_result)

--- a/R/sha_compare.R
+++ b/R/sha_compare.R
@@ -19,8 +19,8 @@ sha_compare <- function(repo, sha_old, sha_new,
   stopifnot(requireNamespace("waldo", quietly = TRUE))
   stopifnot(requireNamespace("withr", quietly = TRUE))
 
-  lib_old <- tempfile("unitr_old_")
-  lib_new <- tempfile("unitr_new_")
+  lib_old <- tempfile("regressr_old_")
+  lib_new <- tempfile("regressr_new_")
   dir.create(lib_old, recursive = TRUE)
   dir.create(lib_new, recursive = TRUE)
 
@@ -59,11 +59,11 @@ sha_compare <- function(repo, sha_old, sha_new,
                  diff = diff,
                  old = old_res,
                  new = new_res),
-            class = "unitr_result")
+            class = "regressr_result")
 }
 
 #' @export
-print.unitr_result <- function(x, ...) {
+print.regressr_result <- function(x, ...) {
   if (x$passed) {
     cat("\u2714 Objects identical\n")
   } else {

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# unitr
+# regressr
 
 Minimal helpers for regression testing across GitHub commit SHAs.
 
@@ -11,13 +11,13 @@ changes between commits in continuous integration and testthat workflows.
 Use `pak` to install from GitHub:
 
 ```r
-pak::pkg_install("ddarmon/unitr")
+pak::pkg_install("ddarmon/regressr")
 ```
 
 ## Example
 
 ```r
-library(unitr)
+library(regressr)
 
 # Compare `main()` results between two SHAs of "org/pkg"
 res <- sha_compare(

--- a/tests/testthat/test-sha.R
+++ b/tests/testthat/test-sha.R
@@ -1,5 +1,5 @@
 library(testthat)
-library(unitr)
+library(regressr)
 
 test_that("Outputs are identical across SHAs", {
   skip_if_offline()


### PR DESCRIPTION
## Summary
- rename `unitr` package to `regressr`
- update README to show new GitHub repo and library calls
- update class and print method names